### PR TITLE
RGB565 encoder

### DIFF
--- a/prbs.js
+++ b/prbs.js
@@ -106,8 +106,8 @@ class PRBS {
 		// * Optional images not supported atm
 
 		this.images = {
-			small: new RGB565(32, rgb5656_32x32, a4_32x32),
-			medium: new RGB565(64, rgb5656_64x64, a4_64x64)
+			small: new RGB565(32, 32, rgb5656_32x32, a4_32x32),
+			medium: new RGB565(64, 64, rgb5656_64x64, a4_64x64)
 		};
 	}
 

--- a/rgb565.js
+++ b/rgb565.js
@@ -74,15 +74,16 @@ const Z_VALUE_LOOKUP_TABLE = [
 */
 
 class RGB565 {
-	constructor(size, rgb565, a4) {
-		this.size = size;
+	constructor(width, height, rgb565, a4) {
+		this.width = width;
+		this.height = height;
 		this.rgb565 = rgb565;
 		this.a4 = a4;
 	}
 
 	async toPNGBase64URI() {
-		const width = this.size;
-		const height = this.size;
+		const width = this.width;
+		const height = this.height;
 
 		const image = new Jimp(width, height);
 
@@ -126,7 +127,8 @@ class RGB565 {
 	async fromImage(image) {
 		const width = image.bitmap.width;
 		const height = image.bitmap.height;
-		this.size = image.bitmap.width;
+		this.width = width;
+		this.height = height;
 
 		this.rgb565 = Buffer.alloc(width * height * 2);
 		this.a4 = Buffer.alloc(Math.floor(width * height / 2));

--- a/rgb565.js
+++ b/rgb565.js
@@ -125,21 +125,19 @@ class RGB565 {
 	}
 
 	async fromImage(image, alpha) {
-		const width = image.bitmap.width;
-		const height = image.bitmap.height;
-		this.width = width;
-		this.height = height;
+		this.width = image.bitmap.width;
+		this.height = image.bitmap.height;
 
-		this.rgb565 = Buffer.alloc(width * height * 2);
+		this.rgb565 = Buffer.alloc(this.width * this.height * 2);
 
 		if (alpha) {
-			this.a4 = Buffer.alloc(Math.floor(width * height / 2));
+			this.a4 = Buffer.alloc(Math.floor(this.width * this.height / 2));
 		}
 
 		// * Badge images are stored as rgb565 data using 8x8 tiles
 		// * Loop over the images tiles
-		for (let tileWalkerY = 0; tileWalkerY < height / 8; tileWalkerY++) {
-			for (let tileWalkerX = 0; tileWalkerX < width / 8; tileWalkerX++) {
+		for (let tileWalkerY = 0; tileWalkerY < this.height / 8; tileWalkerY++) {
+			for (let tileWalkerX = 0; tileWalkerX < this.width / 8; tileWalkerX++) {
 
 				// * Loop over the current 8x8 tile x,y
 				for (let tileY = 0; tileY < 8; tileY++) {
@@ -153,7 +151,7 @@ class RGB565 {
 						const z = Z_VALUE_LOOKUP_TABLE[tileX][tileY];
 
 						// * Actual color index
-						const i = z + (tileWalkerY * 8 * width) + (tileWalkerX * 64);
+						const i = z + (tileWalkerY * 8 * this.width) + (tileWalkerX * 64);
 
 						const rgba = image.getPixelColor(x, y);
 


### PR DESCRIPTION
Add encoder for RGB565 (and A4) images. This PR adds a new function `fromImage(image, alpha)`.

- `image` is a Jimp image
- `alpha` is a bool to tell whether to store A4 data or not

Some other changes have been made, like splitting RGB565 size to width and height, and adding support for empty A4 data to the decoder, to prepare support for other files.